### PR TITLE
src/*.hpp: fix build failures with gcc 13

### DIFF
--- a/src/Base.hpp
+++ b/src/Base.hpp
@@ -11,6 +11,7 @@
 #include "SHASTA_ASSERT.hpp"
 
 #include "array.hpp"
+#include "cstdint.hpp"
 #include "iostream.hpp"
 #include "stdexcept.hpp"
 #include "string.hpp"

--- a/src/PeakFinder.hpp
+++ b/src/PeakFinder.hpp
@@ -50,6 +50,7 @@
 ***********************************************************************************************************************/
 
 
+#include "cstdint.hpp"
 #include "stdexcept.hpp"
 #include "iostream.hpp"
 #include "utility.hpp"

--- a/src/PngImage.hpp
+++ b/src/PngImage.hpp
@@ -2,6 +2,7 @@
 #define SHASTA_PNG_IMAGE_HPP
 
 #include <png.h>
+#include "cstdint.hpp"
 #include "string.hpp"
 #include "vector.hpp"
 

--- a/src/dset64-gccAtomic.hpp
+++ b/src/dset64-gccAtomic.hpp
@@ -1,6 +1,7 @@
 #if !defined(__DSET64_GCC_ATOMIC_HPP)
 #define __DSET64_GCC_ATOMIC_HPP
 
+#include <cstdint>
 #include <stdexcept>
 
 /**

--- a/src/platformDependent.hpp
+++ b/src/platformDependent.hpp
@@ -1,6 +1,7 @@
 #ifndef SHASTA_PLATFORM_DEPENDENT_HPP
 #define SHASTA_PLATFORM_DEPENDENT_HPP
 
+#include "cstdint.hpp"
 #include "string.hpp"
 
 namespace shasta {

--- a/src/shortestPath.hpp
+++ b/src/shortestPath.hpp
@@ -33,6 +33,7 @@
 
 // Standard library.
 #include "cstddef.hpp"
+#include "cstdint.hpp"
 #include <queue>
 #include "vector.hpp"
 

--- a/src/span.hpp
+++ b/src/span.hpp
@@ -2,6 +2,7 @@
 #define SHASTA_SPAN_HPP
 
 #include "algorithm.hpp"
+#include "cstdint.hpp"
 #include "iostream.hpp"
 #include "iterator.hpp"
 #include <span>


### PR DESCRIPTION
As seen in [Debian Bug#1042196], shasta is affected by multiple occurrences of uint*_t types not declared in the scope of their use when compiled with gcc 13, for instance:

	In file included from /<<PKGBUILDDIR>>/src/AssembledSegment.hpp:5,
	                 from /<<PKGBUILDDIR>>/src/AssembledSegment.cpp:2:
	/<<PKGBUILDDIR>>/src/Base.hpp:35:18: error: ‘uint8_t’ was not declared in this scope
	   35 |     static array<uint8_t, 256> table;
	      |                  ^~~~~~~
	/<<PKGBUILDDIR>>/src/Base.hpp:17:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
	   16 | #include "string.hpp"
	  +++ |+#include <cstdint>
	   17 |

This patch implements a variant of the suggested fix, taking into account the existence of cstdint.hpp to check the cpu architecture (at the notable exception of src/dset64-gccAtomic.hpp, where this felt redundant).

[Debian Bug#1042196]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1042196