### PR TITLE
Fix new missing headers with newer gcc 13.2.0.

### DIFF
--- a/src/CompactUndirectedGraph.hpp
+++ b/src/CompactUndirectedGraph.hpp
@@ -26,6 +26,7 @@
 #include <boost/graph/iteration_macros.hpp>
 
 // Standard library.
+#include "algorithm.hpp"
 #include "array.hpp"
 #include "iostream.hpp"
 #include  <limits>

--- a/src/mode3-PathGraph.cpp
+++ b/src/mode3-PathGraph.cpp
@@ -13,6 +13,7 @@ using namespace mode3;
 #include <boost/icl/interval_set.hpp>
 
 // Standard library.
+#include <bitset>
 #include "fstream.hpp"
 #include "iostream.hpp"
 #include <queue>

--- a/src/shortestPath.hpp
+++ b/src/shortestPath.hpp
@@ -32,6 +32,7 @@
 #include <boost/graph/iteration_macros.hpp>
 
 // Standard library.
+#include "algorithm.hpp"
 #include "cstddef.hpp"
 #include "cstdint.hpp"
 #include <queue>


### PR DESCRIPTION
As seen in [Debian bug #1059139], shasta started failing to build from source with gcc 13.2.0, which pushed further the non-transitive inclusion of various standard headers, making their explicit inclusion necessary in the end-developper's source code.

This fixes errors in src/CompactUndirectedGraph.hpp:

	/<<PKGBUILDDIR>>/src/CompactUndirectedGraph.hpp:573:14: error: ‘reverse’ is not a member of ‘std’

in src/shortestPath.hpp:

	/<<PKGBUILDDIR>>/src/shortestPath.hpp:131:18: error: ‘reverse’ is not a member of ‘std’

and in src/mode3-PathGraph.cpp:

	/<<PKGBUILDDIR>>/src/mode3-PathGraph.cpp:677:28: error: ‘bitset’ in namespace ‘std’ does not name a template type

[Debian bug #1059139]: https://bugs.debian.org/1059139