### PR TITLE
remove obsolete boost-system library

### DIFF
--- a/dynamicExecutable/CMakeLists.txt
+++ b/dynamicExecutable/CMakeLists.txt
@@ -42,10 +42,6 @@ if(SHASTA_LONG_MARKERS)
     add_definitions(-DSHASTA_LONG_MARKERS)
 endif(SHASTA_LONG_MARKERS)
 
-# Definitions needed to eliminate dependency on the boost system library.
-add_definitions(-DBOOST_SYSTEM_NO_DEPRECATED)
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
-
 # This is needed to avoid some Boost warnings about deprecated messages.
 # We canot fix this in Shasta as it is a Boost problem.
 # It can be removed if Boost is fixed.
@@ -72,13 +68,13 @@ if(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
-        atomic boost_system boost_program_options boost_chrono boost_serialization spoa png z 
+        atomic boost_program_options boost_chrono boost_serialization spoa png z 
         lapack blas quadmath pthread)
 else(X86_64)
     target_link_libraries(
         shastaDynamicExecutable
         shastaDynamicLibrary
-        atomic boost_system boost_program_options boost_chrono boost_serialization spoa png z 
+        atomic boost_program_options boost_chrono boost_serialization spoa png z 
         lapack blas pthread)
 endif(X86_64)
 

--- a/dynamicLibrary/CMakeLists.txt
+++ b/dynamicLibrary/CMakeLists.txt
@@ -43,10 +43,6 @@ if(SHASTA_LONG_MARKERS)
     add_definitions(-DSHASTA_LONG_MARKERS)
 endif(SHASTA_LONG_MARKERS)
 
-# Definitions needed to eliminate dependency on the boost system library.
-add_definitions(-DBOOST_SYSTEM_NO_DEPRECATED)
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
-
 # This is needed to avoid some Boost warnings about deprecated messages.
 # We canot fix this in Shasta as it is a Boost problem.
 # It can be removed if Boost is fixed.

--- a/staticExecutable/CMakeLists.txt
+++ b/staticExecutable/CMakeLists.txt
@@ -38,10 +38,6 @@ if(SHASTA_LONG_MARKERS)
     add_definitions(-DSHASTA_LONG_MARKERS)
 endif(SHASTA_LONG_MARKERS)
 
-# Definitions needed to eliminate dependency on the boost system library.
-add_definitions(-DBOOST_SYSTEM_NO_DEPRECATED)
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
-
 # This is needed to avoid some Boost warnings about deprecated messages.
 # We canot fix this in Shasta as it is a Boost problem.
 # It can be removed if Boost is fixed.
@@ -67,14 +63,14 @@ if(X86_64)
     target_link_libraries(
         shastaStaticExecutable
         shastaStaticLibrary
-        atomic boost_system boost_program_options boost_chrono boost_serialization  spoa png z
+        atomic boost_program_options boost_chrono boost_serialization  spoa png z
         lapack blas gfortran quadmath
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 else(X86_64)
     target_link_libraries(
         shastaStaticExecutable
         shastaStaticLibrary
-        atomic boost_system boost_program_options boost_chrono boost_serialization spoa png z
+        atomic boost_program_options boost_chrono boost_serialization spoa png z
         lapack blas gfortran
         -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 endif(X86_64) 

--- a/staticLibrary/CMakeLists.txt
+++ b/staticLibrary/CMakeLists.txt
@@ -38,10 +38,6 @@ if(SHASTA_LONG_MARKERS)
     add_definitions(-DSHASTA_LONG_MARKERS)
 endif(SHASTA_LONG_MARKERS)
 
-# Definitions needed to eliminate dependency on the boost system library.
-add_definitions(-DBOOST_SYSTEM_NO_DEPRECATED)
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
-
 # This is needed to avoid some Boost warnings about deprecated messages.
 # We canot fix this in Shasta as it is a Boost problem.
 # It can be removed if Boost is fixed.


### PR DESCRIPTION
it was removed from boost 1.89

the current ubuntu package doesn't build because of this: https://bugs.launchpad.net/ubuntu/+source/shasta/+bug/2141453